### PR TITLE
PHP 8.2: Fix deprecation

### DIFF
--- a/generated/Endpoint/ChatPostMessage.php
+++ b/generated/Endpoint/ChatPostMessage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace JoliCode\Slack\Api\Endpoint;
 
+#[\AllowDynamicProperties]
 class ChatPostMessage extends \JoliCode\Slack\Api\Runtime\Client\BaseEndpoint implements \JoliCode\Slack\Api\Runtime\Client\Endpoint
 {
     use \JoliCode\Slack\Api\Runtime\Client\EndpointTrait;


### PR DESCRIPTION
We noticed that our slack integration was broken because of
 dynamic property declarations. There is an issue upstream,
 but let's for this for now so that we can move along. We will 
revert this when the upstream fix has been implemented.

Connects: https://github.com/iFixit/ifixit/issues/49373